### PR TITLE
Use JSON format instead of plain text in SessionStart hook

### DIFF
--- a/integration/claude-code/hooks/memory_session_start.py
+++ b/integration/claude-code/hooks/memory_session_start.py
@@ -131,8 +131,15 @@ def main():
         register_session(session_id, project_id)
         
         # Output primer to stdout (will be injected into session)
+        # Use JSON format for reliable injection as system reminder
         if primer:
-            print(primer)
+            output = {
+                "hookSpecificOutput": {
+                    "hookEventName": "SessionStart",
+                    "additionalContext": primer
+                }
+            }
+            print(json.dumps(output))
             
     except Exception:
         # Never crash


### PR DESCRIPTION
Change primer output from plain text to JSON format with hookSpecificOutput. Plain text output was not reliably appearing in Claude's context, while JSON format with hookEventName and additionalContext ensures the primer is injected as a system reminder.